### PR TITLE
Include dependencies in Lambda package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ venv.bak/
 # editors
 .sw[a-z]
 .idea/
+
+# external dependencies
+/lib

--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,3 @@ venv.bak/
 # editors
 .sw[a-z]
 .idea/
-
-# external dependencies
-/lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
 after_success:
   - codecov
 before_deploy:
-  - pip install -t .lib/ -r requirements/base.txt
+  - pip install -t lib/ -r requirements/base.txt
 deploy:
   provider: lambda
   function_name: tank-level-extractor
@@ -25,4 +25,4 @@ deploy:
   module_name: extractor/extractor
   handler_name: extract
   environment_variables:
-    - PYTHONPATH=.lib/
+    - PYTHONPATH=lib/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,21 @@ matrix:
     - python: '3.7'
       dist: xenial
       sudo: true
+env:
+  - SH=bash
+  - PYTHONPATH=.lib/
 install:
-  - pip install -r requirements/test.txt
+  - pip install -t .lib/ -r requirements/test.txt
 script:
   - pytest --cov-report=xml --cov=extractor
   - flake8
   - pylint **/*.py
 after_success:
   - codecov
+before_deploy:
+  # uninstall all test dependencies
+  - rm -rf .lib
+  - pip install -t .lib/ -r requirements/base.txt
 deploy:
   provider: lambda
   function_name: tank-level-extractor
@@ -22,3 +29,5 @@ deploy:
   runtime: python3.7
   module_name: extractor/extractor
   handler_name: extract
+  environment_variables:
+    - PYTHONPATH=.lib/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,8 @@ matrix:
     - python: '3.7'
       dist: xenial
       sudo: true
-env:
-  global:
-    - SH=bash
-    - PYTHONPATH=.lib/
-    - 'PATH=$PATH:$(pwd).lib/bin'
 install:
-  - pip install -t .lib/ -r requirements/test.txt
+  - pip install -r requirements/test.txt
 script:
   - pytest --cov-report=xml --cov=extractor
   - flake8
@@ -20,8 +15,6 @@ script:
 after_success:
   - codecov
 before_deploy:
-  # uninstall all test dependencies
-  - rm -rf .lib
   - pip install -t .lib/ -r requirements/base.txt
 deploy:
   provider: lambda

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   global:
     - SH=bash
     - PYTHONPATH=.lib/
+    - 'PATH=$PATH:$(pwd).lib/bin'
 install:
   - pip install -t .lib/ -r requirements/test.txt
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ matrix:
       dist: xenial
       sudo: true
 env:
-  - SH=bash
-  - PYTHONPATH=.lib/
+  global:
+    - SH=bash
+    - PYTHONPATH=.lib/
 install:
   - pip install -t .lib/ -r requirements/test.txt
 script:

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Lambda function to extract Amazon SES emails from S3
 
 [![Build Status](https://travis-ci.com/vag-fuel/aws-lambda-email-extractor.svg?branch=master)](https://travis-ci.com/vag-fuel/aws-lambda-email-extractor)
 [![codecov](https://codecov.io/gh/vag-fuel/aws-lambda-email-extractor/branch/master/graph/badge.svg)](https://codecov.io/gh/vag-fuel/aws-lambda-email-extractor)
-[![pyup](https://pyup.io/repos/github/vag-fuel/aws-lambda-email-extractor/shield.svg?t=1550510147428)]()
+[![Updates](https://pyup.io/repos/github/vag-fuel/aws-lambda-email-extractor/shield.svg)](https://pyup.io/repos/github/vag-fuel/aws-lambda-email-extractor/)


### PR DESCRIPTION
We need the dependencies to be deployed to AWS Lamda, too. This adds a step before deployment to install the dependencies in ./lib so that they are included with in the zip file that's uploaded to AWS.